### PR TITLE
WEB-51: add support for WEBP images

### DIFF
--- a/archives/templates/base.html
+++ b/archives/templates/base.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<html lang="en-GB">
 <head>
   <script>0</script> <!-- workaround for FOUC errors on FF -->
   <title>nosher.net {% if page_title %} - {{ page_title }}{% endif %}</title>
@@ -26,93 +27,61 @@
     <a href="/content/saxonhorse/">Saxon horse</a> | 
     <a href="#navigation"><nobr>more ▼</nobr></a>
   </div>
-
   <header><p>nosher.net</p></header>
-
   <main>{% block content %}{% endblock %}</main>
-
   <sidebar>{% block sidebar %}{% endblock %}</sidebar>
-
   <nav>
     <a name="navigation"></a>
     <ul>
-
         <!-- home -->
         <li><a href="/">Home</a></li>
-
         <!-- photos -->
         <li><a href="/images/">A life in photos</a>
         {% if years %}
           <p class="navlink">
-          {% for year in years %}
-            <nobr><a href="/images/{{ year.year }}">{{ year.year }}</a> <span class="count">[{{ year.count }}]</span>{% if year.hasNew %}<span class="inew">•</span>{% endif %}{%if not forloop.last%},&nbsp;{%endif%}</nobr>
-          {% endfor %}
+          {% for year in years %}<nobr>{% if year.hasNew %}<span class="inew">•</span>{% endif %}<a href="/images/{{ year.year }}">{{ year.year }}</a>{%if not forloop.last%}, {%endif%}</nobr>
+        {% endfor %}
           <br clear="left" /><span class="inew">•</span> denotes new albums</p>
         {% endif %}
         {% if groups %}
           <p class="navlink">
-          {% for group in groups %}
-            <a href="/images?title={{ group.title|urlencode }}&group={{ group.keys|urlencode }}">{{ group.title }}</a><br />
-          {% endfor %}
+          {% for group in groups %}<a href="/images?title={{ group.title|urlencode }}&group={{ group.keys|urlencode }}">{{ group.title }}</a><br />
+        {% endfor %}
           </p>
         {% endif %}
         </li>
-
         <!-- computer adverts -->
-        <li><a href="/archives/computers/">A history of the microcomputer industry in 300 adverts</a>
-        {% if companies %}
+        <li><a href="/archives/computers/">A history of the microcomputer industry in 300 adverts</a>{% if companies %}
         <p class="navlink">
         {% for company in companies %}{% if company.company != "" %}{% if company.total == 1 %}{% if company.company|length < 30 %}
-        <nobr>{% endif %}<a href="/archives/computers/{{ company.company|get_first_advert }}">{{ company.company }} <span>[{{ company.total }}]</span></a>{%if not forloop.last%},&nbsp;{%endif%}{% if company.company|length < 30 %}</nobr>{% endif %}{% else %}{% if company.company != "" %}{% if company.company|length < 30 %}
-        <nobr>{% endif %}<a href="/archives/computers/?type=source&value={{ company.company }}">{{ company.company }} <span>[{{ company.total }}]</span></a>{%if not forloop.last%},&nbsp;{%endif%}{% if company.company|length < 30 %}</nobr>{% endif %}{% endif %}{% endif %}{% endif %}{% endfor %}</p>{% endif %}</li>
-
+        <nobr>{% endif %}<a href="/archives/computers/{{ company.company|get_first_advert }}">{{ company.company }}</a>{%if not forloop.last%},&nbsp;{%endif%}{% if company.company|length < 30 %}</nobr>{% endif %}{% else %}{% if company.company != "" %}{% if company.company|length < 30 %}
+        <nobr>{% endif %}<a href="/archives/computers/?type=source&value={{ company.company }}">{{ company.company }}</a>{%if not forloop.last%},&nbsp;{%endif%}{% if company.company|length < 30 %}</nobr>{% endif %}{% endif %}{% endif %}{% endif %}{% endfor %}</p>{% endif %}</li>
         <!-- the AJO Archive -->
         <li><a href="/content/ajo/">The Arnewood Jazz Orchestra Archive</a></li>
-
         <!-- RAF Halton 69th Entry Archive -->
-        <li><a href="/content/raf69th">The RAF Halton 69th Entry Archive</a>
-        {%if section == "raf69th" %}
-            <p class="navlink"><ul class="contentlist">{% include "content/rafnav.html" %}</ul></p>
-        {% endif %}
-        </li>
-
+        <li><a href="/content/raf69th">The RAF Halton 69th Entry Archive</a>{%if section == "raf69th" %}
+            <p class="navlink"><ul class="contentlist">{% include "content/rafnav.html" %}</ul></p>{% endif %}</li>
         <!-- The Saxon Horse -->
-        <li><a href="/content/saxonhorse/">The Saxon Horse burial at Eriswell</a>
-        {%if section == "saxonhorse" %}
-            <p class="navlink"><ul class="contentlist">{% include "content/saxonnav.html" %}</ul></p>
-        {% endif %}
-        </li>
-
+        <li><a href="/content/saxonhorse/">The Saxon Horse burial at Eriswell</a>{%if section == "saxonhorse" %}
+            <p class="navlink"><ul class="contentlist">{% include "content/saxonnav.html" %}</ul></p>{% endif %}</li>
         <!-- Flint knapping Brandon -->
-        <li><a href="/content/brandonflint/">An 1887 history of flint knapping in Brandon</a>
-        </li>
-
+        <li><a href="/content/brandonflint/">An 1887 history of flint knapping in Brandon</a></li>
         <!-- Family recipes -->
-        <li><a href="/content/recipes/">Family recipes</a>
-        </li>
-
+        <li><a href="/content/recipes/">Family recipes</a></li>
         <!-- search -->
         <li>
-        <p class="navlink">
-            <form action="/search" method="get">
-            <input id="query" type="text" value="{{ query }}" name="q" maxlength="100" class="stextnav" required />
-            {% if years %} 
-            <input id="type" type="hidden" value="photos" name="filter" />
-            {% endif %}    
-            {% if companies %} 
-            <input id="type" type="hidden" value="ads" name="filter" />
-            {% endif %}    
-            <input type="submit" value="Search" class="sbutton" />
-            </form>
-        </p>
+        <form action="/search" method="get" class="navlink">
+            <label>Search: <input id="query" type="text" value="{{ query }}" name="q" maxlength="100" class="stextnav" required /></label>{% if years %}
+            <input id="type" type="hidden" value="photos" name="filter" />{% endif %}{% if companies %}
+            <input id="type" type="hidden" value="ads" name="filter" />{% endif %}
+            <input type="submit" value="Go" class="sbutton" />
+        </form>
         </li>
     </ul>
   </nav>
-
   <footer>
     <p>{%if feedback %}Feedback: {{ feedback }}<br />{% endif %}&copy; nosher.net 1999-{{ ""|get_now }}{%if mtime %}. Last updated: <nobr>{{ mtime }}</nobr>{% endif %}
     </p>
   </footer>
-
 </body>
-
+</html>

--- a/archives/templates/computers/advert.html
+++ b/archives/templates/computers/advert.html
@@ -73,7 +73,7 @@
     </p>
     <h2>From {%if item.source %}{{ item.source }}{% else %}{%if item.type == "channel" %}sales brochure{% else %}Source unknown{% endif %}{% endif %}</h2>
     <div class="zoomer">
-      <img src="{{ page_image }}" class="ad" width="{{width}}" height="{{height}}"/>
+      <img src="{{ page_image }}" class="ad" style="aspect-ratio: {{ aspect }};" />
     </div>
     <div class="magicon"><button id="zoom" type="button">🔍 click to zoom</button></div>
     
@@ -113,7 +113,7 @@
         <div class="adthumb">
           <a href="{{ rel.adid|get_first_image }}">            
         {% endif %}
-          <img src="{{url}}/images/{{ rel.adid|get_first_image }}-s.jpg" width="100" height="100" /><br />
+          <img src="{{url}}/images/{{ rel.adid|get_first_image }}-s.jpg" /><br />
           {% if rel.adid != item.adid %}</a>{% endif %}
           <span>{{rel.year|get_year_only}}</span>
         </div>

--- a/archives/views.py
+++ b/archives/views.py
@@ -518,6 +518,7 @@ def computer_advert_html(request, advert, adid):
         'page_image': _get_page_image("{}-m.jpg".format(adid)),
         'width': imgw,
         'height': imgh,
+        'aspect': (imgw / imgh),
         'item': item,
         'page_title': page_title,
         'staticServer': WEBROOT,

--- a/external/img2
+++ b/external/img2
@@ -1,0 +1,57 @@
+#!/usr/bin/python3
+
+from urllib import parse
+import os
+import sys
+import subprocess
+
+ROOT = "/home/httpd/nosher.net/docs/"
+img = width = content_type = request = output = None
+
+request = [("i", "https://static.nosher.net/images/2023/2023-09-02DragonflyRide/imgp6441-s.jpg"), ("t", "webp")]
+request = [("i", "https://static.nosher.net/archives/computers/images/ads_002-s.jpg"), ("t", "webp")]
+
+if "QUERY_STRING" in os.environ:
+    request = parse.parse_qsl(os.environ["QUERY_STRING"])
+
+if request:
+    for (k,v) in request:
+        if k == "i":
+            img = v
+            img = img.replace(".jpg", "").replace(".webp", "").replace("https://static.nosher.net", "")
+        elif k == "w":
+            width = v
+        elif k == "t":
+            content_type = v
+    try:
+        fpath = ROOT + "/" + img
+        if os.path.isfile(fpath + ".jpg"):
+            fpath = fpath + ".jpg"
+        else:
+            fpath = fpath + ".webp"
+            # is webp already
+        print ("*", fpath)
+        # TODO : shortcut for when converting to webp and already webp
+        if content_type == "webp":
+            data = subprocess.run(["/usr/bin/cwebp", "-quiet", "-o", "-", "-m", "2", fpath], stdout=subprocess.PIPE)
+        elif content_type == "jpg":
+            try:
+                data = subprocess.run(["magick", fpath, "JPEG:-"], stdout=subprocess.PIPE)
+            except:
+                data = subprocess.run(["convert", fpath, "JPEG:-"], stdout=subprocess.PIPE)
+
+        else:
+            print("Content-type: text/html\n\n")
+            print("Exception processing file: invalid format {} for {}".format(content_type, fpath))
+            sys.exit()
+                
+        sys.stdout.buffer.write(bytes("Content-type: image/{}\n\n".format(content_type), "utf-8"))
+        sys.stdout.buffer.write(data.stdout)
+
+    except Exception as err:
+        print("Content-type: text/html\n\n")
+        print("Exception processing file: ", err)
+    
+else:
+    print("Content-type: text/html\n\n")
+    print("Error: not a valid request")

--- a/external/img2
+++ b/external/img2
@@ -38,7 +38,7 @@ if request:
             fpath = fpath + ".jpg"
         else:
             fpath = fpath + ".webp"
-            # the image is webp already
+
         # TODO : provide no-op shortcut for converting to webp when image is already webp. 
         # See https://github.com/nosher/dotnet/issues/55
         if content_type == "webp":

--- a/external/img2
+++ b/external/img2
@@ -38,9 +38,9 @@ if request:
             fpath = fpath + ".jpg"
         else:
             fpath = fpath + ".webp"
-            # is webp already
-        print ("*", fpath)
-        # TODO : provide no-op shortcut for converting to webp when image is already webp
+            # the image is webp already
+        # TODO : provide no-op shortcut for converting to webp when image is already webp. 
+        # See https://github.com/nosher/dotnet/issues/55
         if content_type == "webp":
             data = subprocess.run(["/usr/bin/cwebp", "-quiet", "-o", "-", "-m", "2", fpath], stdout=subprocess.PIPE)
         elif content_type == "jpg":

--- a/external/img2
+++ b/external/img2
@@ -1,5 +1,13 @@
 #!/usr/bin/python3
 
+"""
+Simple cgi-bin script to convert an image on the fly from JPEG to or from WEBP, and 
+serve it in place of the original
+
+Requires ImageMagick for converting to JPEG, and cwebp for converting to WEBP
+
+"""
+
 from urllib import parse
 import os
 import sys
@@ -8,8 +16,9 @@ import subprocess
 ROOT = "/home/httpd/nosher.net/docs/"
 img = width = content_type = request = output = None
 
-request = [("i", "https://static.nosher.net/images/2023/2023-09-02DragonflyRide/imgp6441-s.jpg"), ("t", "webp")]
-request = [("i", "https://static.nosher.net/archives/computers/images/ads_002-s.jpg"), ("t", "webp")]
+# test requests - uncomment to use
+# request = [("i", "https://static.nosher.net/images/2023/2023-09-02DragonflyRide/imgp6441-s.jpg"), ("t", "webp")]
+# request = [("i", "https://static.nosher.net/archives/computers/images/ads_002-s.jpg"), ("t", "webp")]
 
 if "QUERY_STRING" in os.environ:
     request = parse.parse_qsl(os.environ["QUERY_STRING"])
@@ -31,7 +40,7 @@ if request:
             fpath = fpath + ".webp"
             # is webp already
         print ("*", fpath)
-        # TODO : shortcut for when converting to webp and already webp
+        # TODO : provide no-op shortcut for converting to webp when image is already webp
         if content_type == "webp":
             data = subprocess.run(["/usr/bin/cwebp", "-quiet", "-o", "-", "-m", "2", fpath], stdout=subprocess.PIPE)
         elif content_type == "jpg":

--- a/external/nosher2.css
+++ b/external/nosher2.css
@@ -11,24 +11,6 @@
     --inset: 12px;
 }
 
-/* latin */
-
-@font-face {
-    font-family: 'Carter One';
-    src: url(https://static.nosher.net/fonts/CarterOne.woff2) format('woff2');
-    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-    font-display: swap;
-}
-
-
-/* latin */
-
-@font-face {
-    font-family: 'Open Sans';
-    src: url(https://static.nosher.net/fonts/OpenSans.woff2) format('woff2');
-    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-    font-display: swap;
-}
 
 @font-face {
     font-family: 'Roboto-Light';
@@ -36,26 +18,9 @@
     font-display: swap;
 }
 
-/* latin */
-
-@font-face {
-    font-family: SegoeUILight;
-    src: local("Segoe UI Light"), url(https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/light/latest.woff2) format("woff2"), url(https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/light/latest.woff) format("woff"), url(https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/light/latest.ttf) format("truetype");
-    font-display: swap;
-}
-
-@font-face {
-    font-family: 'Source Code Pro';
-    src: url(https://static.nosher.net/fonts/SourceCodePro.woff2) format('woff2');
-    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-    font-display: swap;
-}
-
 @font-face {
     font-family: 'charterregular';
-    src: url('https://static.nosher.net/fonts/charter_regular-webfont.eot');
-    src: url('https://static.nosher.net/fonts/charter_regular-webfont.eot?#iefix') format('embedded-opentype'),
-         url('https://static.nosher.net/fonts/charter_regular-webfont.woff') format('woff');
+    src: url('https://static.nosher.net/fonts/charter_regular-webfont.woff') format('woff');
     font-weight: normal;
     font-style: normal;
     font-display: swap;
@@ -92,7 +57,7 @@ hr {
 
 h1 {
     display: inline-block;
-    font-family: 'Roboto-Light', sans-serif;
+    font-family: "Roboto-Light", sans-serif;
     text-shadow: rgba(30, 30, 30, 0.2) 3px 2px 3px;
     color: var(--headers);
     margin: 4px 12px 20px 0;
@@ -101,7 +66,7 @@ h1 {
 }
 
 h2, h3 {
-    font-family: 'Roboto-Light', sans-serif;
+    font-family: "Roboto-Light", sans-serif;
     color: var(--headers2);
     margin: 22px 0 12px 0;
     font-size: 160%;
@@ -110,12 +75,12 @@ h2, h3 {
 }
 
 h3 {
-    font-family: 'Roboto-Light', sans-serif;
+    font-family: "Roboto-Light", sans-serif;
     font-size: 140%;
     margin: 22px 0 12px 0;
 }
 
-@media screen and (max-width: 1250px) {
+@media screen and (max-width: 1000px) {
     h1 {
         display: block;
         margin: 0 0 12px 0;
@@ -144,7 +109,7 @@ p {
     line-height: 1.5;
 }
 
-@media screen and (max-width: 1250px) {
+@media screen and (max-width: 1000px) {
     p {
         margin: 0 0.75em 0.75em 8px;
     }
@@ -153,17 +118,16 @@ p {
 /* Body */
 
 body {
-    font-family: 'charterregular', serif; 
-    /* font-family: 'SegoeUIlight', sans-serif; */
+    font-family: "charterregular", serif;
     text-rendering: optimizeLegibility;
-    font-weight: 400;
+    font-weight: 300;
     width: 100vw;
     font-size: 21px;
     color: #333;
     min-height: 100vh;
     margin: 0;
     padding: 0;
-    background-image: url("https://static.nosher.net/graphics/bg4.jpg");
+    background-image: url("https://static.nosher.net/graphics/bg4.webp");
     overflow-x: hidden;
 }
 
@@ -171,7 +135,7 @@ body {
     overflow-y: scroll !important;
 }
 
-@media screen and (max-width: 1250px) {
+@media screen and (max-width: 1000px) {
     body {
         font-size: 11pt;
     }
@@ -182,11 +146,11 @@ body {
 .body {
     display: grid;
     grid-template-rows: 70px auto 80px;
-    grid-template-columns: minmax(280px, 2.0fr) 10fr 2fr;
+    grid-template-columns: minmax(280px, 2.0fr) 10fr minmax(240px, 2.0fr);
     grid-template-areas: "header header header" "nav    content    sidebar" "footer  footer  footer";
 }
 
-@media screen and (max-width: 1250px) {
+@media screen and (max-width: 1000px) {
     .body {
         display: grid;
         grid-template-columns: auto;
@@ -205,27 +169,22 @@ body {
     grid-template-areas: ". header ." ".    content   ." ".    footer    .";
 }
 
-@media screen and (max-width: 1250px) {
+@media screen and (max-width: 1000px) {
     #home {
         margin-top: 0;
         display: grid;
-        grid-template-columns: auto;
+        grid-template-columns: 1fr;
         grid-template-rows: auto auto 40px;
         grid-template-areas: "header" "content" "footer";
     }
 }
 
-.homelist li {
-    margin-left: -24px;
-}
-
 #home>header, header {
     background-color: var(--header);
-    font-family: 'Carter One';
+    font-family: 'Arial', sans-serif;
     color: #fff;
     font-size: 220%;
     text-shadow: 3px 2px 2px #333;
-    padding-right: 10px;
     grid-area: header;
 }
 
@@ -235,20 +194,19 @@ body {
 }
 
 #home>content {
-    padding-left: 20px;
     background-color: #fff;
     grid-area: content;
 }
 
-@media screen and (max-width: 1250px) {
+@media screen and (max-width: 1000px) {
     #home>content {
-        padding-left: 0;
+        padding: 0;
     }
 }
 
 #home>footer, footer {
     background-color: var(--header);
-    color: #bcc8e2;
+    color: #ffffff;
     padding: 8px;
     vertical-align: baseline;
     grid-area: footer;
@@ -256,7 +214,7 @@ body {
 
 #home>footer p, footer p {
     text-align: right;
-    margin: 4px 20px 0 0;
+    margin: 0 20px 0 0;
 }
 
 #home .splash {
@@ -273,7 +231,7 @@ main {
     grid-area: content;
 }
 
-@media screen and (max-width: 1250px) {
+@media screen and (max-width: 1000px) {
     main {
         padding: 0;
     }
@@ -281,12 +239,12 @@ main {
         padding: 0 4px 8px 0;
     }
     header, nav, footer, header {
-        width: 99%; 
         padding: 0;
         margin: 0;
     }
     footer p {
         font-size: 70%;
+        padding: 0;
     }
 }
 
@@ -323,7 +281,7 @@ main {
     font-size: 80%;
     margin: 0;
 }
-@media screen and (max-width: 1250px) {
+@media screen and (max-width: 1000px) {
     #sidebyside {
         margin: 0;
         display: grid;
@@ -342,14 +300,14 @@ main {
         margin-top: 0;
     }
     #sidebyside>list ul {
-        margin-left: -12px;
+        margin-left: -22px;
     }
     #sidebyside>list ul li {
         margin: 0 12px 12px 0;
     }
     #sidebyside>list h1, #sidebyside>list h3 {
         margin: 0;
-        padding: var(--pad) 0 var(--pad) var(--inset);
+        padding: var(--pad) 0 var(--pad) 4px;
     }
     #sidebyside>photo img {
         width: 100px;
@@ -382,16 +340,17 @@ nav ul {
     margin: 0;
 }
 nav ul li {
-    font-family: 'SegoeUILight', sans-serif;
+    font-family: 'Roboto-Light', sans-serif;
     font-size: 110%;
     padding: 8px;
     line-height: 1.1em;
+    font-weight: 300;
     border-bottom: 0.5px solid #838ca0;
     list-style-type: none;
     list-style-position: outside;
 }
 
-@media screen and (max-width: 1250px) {
+@media screen and (max-width: 1000px) {
     nav ul li {
         padding: 6px;
         border-bottom: 0.5px solid #000;
@@ -433,14 +392,23 @@ ul.index li {
 }
 
 
-@media screen and (max-width: 1250px) {
+@media screen and (max-width: 1000px) {
+    ul.index {
+       margin: 8px 8px 20px 14px;
+       padding: 0;
+    }
+
+    ul.index li {
+        margin-bottom: 8px;
+        margin-left: 6px;
+    }
     nav ul li {
         line-height: 1.8em;
     }
     .navlite {
         display: block;
         background-color: #ddd;
-        font-family: 'SegoeUILight', sans-serif;
+        font-family: Arial, sans-serif;
         font-size: 90% !important;
         padding: 6px 0 6px 0;
         text-align: center;
@@ -469,7 +437,7 @@ sidebar {
 .adthumb, .adthumb_dim {
     text-align: center;
     font-size: 70%;
-    font-family: "SegoeUILight";
+    font-family: Arial, sans-serif;
     margin: 0 8px 0 8px;
 }
 .adthumb img, .adthumb_dim img {
@@ -486,7 +454,7 @@ sidebar {
     display: grid;
     grid-template-columns: 1fr 1fr;
 }
-@media screen and (max-width: 1250px) {
+@media screen and (max-width: 1000px) {
     sidebar {
         width: 99%;
         padding: 8px 0 8px 0;
@@ -519,7 +487,7 @@ sidebar {
     margin: 0;
 }
 
-@media screen and (max-width: 1250px) {
+@media screen and (max-width: 1000px) {
     .catalogue {
         column-count: 1;
     }
@@ -563,18 +531,17 @@ sidebar {
 }
 
 article.thumb p {
-    /*font-family: 'Open Sans', sans-serif;*/
     line-height: 1.2;
     font-size: 70%;
     color: #606060;
 }
 
-@media screen and (max-width: 1250px) {
+@media screen and (max-width: 1000px) {
     .thumbnails, .searchthumbnails {
-        grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
+        grid-template-columns: repeat(auto-fill, minmax(60px, 1fr));
         grid-gap: 12px;
-        padding: 4px;
-        max-width: 95%;
+        padding: 4px 4px 4px 8px;
+        max-width: 94%;
     }
     article.thumb p {
         font-size: 75%;
@@ -591,7 +558,7 @@ article.thumb img {
     width: 100%;
     margin-bottom: 12px;
     border: 1px solid #aaaaaa;
-    border-radius: 2px;
+    aspect-ratio: 1 / 1;
 }
 
 .search img {
@@ -604,9 +571,15 @@ article.thumb img {
     margin: 0;
 }
 
-@media screen and (max-width: 1250px) {
+@media screen and (max-width: 1000px) {
     .search img {
         width: 80px;
+    }
+    article.thumb img {
+        margin-bottom: 2px;
+    }
+    article.thumb p {
+        margin-left: 0;
     }
 }
 
@@ -614,14 +587,17 @@ article.thumb img {
     margin: 0 0 12px 0;
 }
 
-@media screen and (max-width: 1250px) {
-    .intro {
-        margin: 4px 4px 0 8px !important;
-    }
-}
-
 .images_intro {
     padding: 2px 20px 8px 2px;
+}
+
+@media screen and (max-width: 1000px) {
+    .intro {
+        margin: 4px 4px 0 0 !important;
+    }
+    .images_intro {
+        padding: 2px 8px 8px 0;
+    }
 }
 
 ul.albums {
@@ -664,6 +640,9 @@ ul.albums li {
     text-align: center;
     overflow-wrap: normal;
 }
+.mphoto img {
+    border: none !important;
+}
 @media (orientation: landscape) {
     #mobile_viewer {
         height: 100%;
@@ -677,7 +656,7 @@ ul.albums li {
     }
 }
 
-@media screen and (max-width: 1250px) {
+@media screen and (max-width: 1000px) {
     #viewer {
         display: none;
     }
@@ -699,7 +678,7 @@ ul.albums li {
     grid-template-areas: ". . ." ".    photoview   photoclose" "capregion capregion capregion";
 }
 
-@media screen and (max-width: 1250px) {
+@media screen and (max-width: 1000px) {
     #viewwindow {
         grid-column: viewport;
         display: inherit;
@@ -715,7 +694,7 @@ ul.albums li {
     visibility: hidden;
 }
 
-@media screen and (max-width: 1250px) {
+@media screen and (max-width: 1000px) {
     .closetext {
         visibility: visible;
     }
@@ -749,7 +728,7 @@ photoclose {
     grid-area: photoclose;
 }
 
-@media screen and (max-width: 1250px) {
+@media screen and (max-width: 1000px) {
     photoclose {
         visibility: hidden;
         width: 0px;
@@ -758,24 +737,27 @@ photoclose {
 
 photoclose img {
     margin: auto 0 auto 12px;
-    width: 20px;
+    width: 20px !important;
     height: 20px;
+    box-shadow: none !important;
+    border: none !important;
 }
 
 photoview img {
     background-color: #ddd;
     height: calc(100vh - 170px);
     margin: 0 auto 0 auto;
+    box-shadow: none;
 }
 
-@media screen and (max-width: 1250px) and (orientation: landscape) {
+@media screen and (max-width: 1000px) and (orientation: landscape) {
     photoview img {
         height: 80vh;
         width: unset;
     }
 }
 
-@media screen and (max-width: 1250px) and (orientation: portrait) {
+@media screen and (max-width: 1000px) and (orientation: portrait) {
     #photoview img {
         width: 90vw;
         height: unset;
@@ -794,7 +776,7 @@ photoview img {
     overflow: hidden;
 }
 
-@media screen and (max-width: 1250px) {
+@media screen and (max-width: 1000px) {
     #wrapper {
         height: 0;
     }
@@ -811,6 +793,9 @@ photoview img {
 #strip div img {
     width: 66px;
     height: 66px;
+    border: none;
+    margin: 0;
+    box-shadow: none;
 }
 
 #strip div.hilite, #strip div.lolite {
@@ -822,7 +807,7 @@ photoview img {
     background-color: #800000;
 }
 
-@media screen and (max-width: 1250px) {
+@media screen and (max-width: 1000px) {
     #strip {
         visibility: hidden;
     }
@@ -840,7 +825,7 @@ photoview img {
     width: 60px;
 }
 
-@media screen and (max-width: 1250px) {
+@media screen and (max-width: 1000px) {
     #fourbox {
         grid-template-rows: 40px 40px;
         grid-template-columns: 40px 40px;
@@ -857,7 +842,7 @@ photoview img {
     background-color: #dddddd;
 }
 
-@media screen and (max-width: 1250px) {
+@media screen and (max-width: 1000px) {
     #fullsize {
         max-width: 85%;
         margin: 0 auto 0 auto;
@@ -881,7 +866,7 @@ p.nextprev:before {
     color: #808080;
 }
 
-@media screen and (max-width: 1250px) {
+@media screen and (max-width: 1000px) {
     .nextprev {
         margin: 8px 4px 18px 8px;
         font-size: 120%;
@@ -914,12 +899,12 @@ p.nextprev:before {
     margin: -2px 0 0 var(--inset);
 }
 
-@media screen and (max-width: 1250px) {
+@media screen and (max-width: 1000px) {
     .stext, .sbutton {
         height: 30px;
     }
     .stext {
-        width: 140px;
+        width: 100px;
     }
 }
 
@@ -928,7 +913,7 @@ p.nextprev:before {
     margin-top: 40px;
 }
 
-@media screen and (max-width: 1250px) {
+@media screen and (max-width: 1000px) {
     .hint {
         visibility: hidden;
     }
@@ -963,13 +948,15 @@ archivedescription {
 
 archivedescription .year {
     font-weight: bold;
+    font-family: "charterregular", sans-serif;
     color: #707070;
     margin: 0;
     font-size: 90%;
 }
 
 archivedescription .title {
-    font-weight: bold;
+    font-family: "charterregular", sans-serif;
+    font-weight: 300;
     color: #202020;
     margin: 4px 0 0 0;
 }
@@ -991,7 +978,7 @@ archivedescription h3 {
     text-decoration: none;
 }
 
-@media screen and (max-width: 1250px) {
+@media screen and (max-width: 1000px) {
     archiveitem {
         grid-template-columns: 80px auto;
         grid-template-rows: auto 8px;
@@ -1027,7 +1014,7 @@ archivedescription h3 {
     margin: 8px 0 24px 0;
 }
 
-.advert {
+.advert, .album {
     color: #303030;
     color: #333;
     padding: 0;
@@ -1065,7 +1052,7 @@ div.magicon {
 }
 
 
-@media screen and (max-width: 1250px) {
+@media screen and (max-width: 1000px) {
         div.zoomer {
             width: 96%;
             padding: 0;
@@ -1103,13 +1090,13 @@ div.magicon {
 }
 
 .origins {
-    font-weight: bold;
+    font-weight: 300;
     background-color: #c4d6db;
     padding: 12px;
-    font-family: "Roboto-Light";
+    font-family: Arial, sans-serif;
 }
 
-@media screen and (max-width: 1250px) {
+@media screen and (max-width: 1000px) {
     .advert {
         text-align: left;
     }
@@ -1120,7 +1107,7 @@ div.magicon {
         box-sizing: border-box;
     }
     .advert p {
-        margin: 0 4px 16px 8px;
+        margin: 0 4px 8px 8px;
     }
     .advert p.nav {
         margin: 0;
@@ -1135,13 +1122,14 @@ div.magicon {
 }
 
 p.navlink {
-    font-size: 80%;
-    line-height: 1.3;
-    font-family: 'SegoeUILight';
+    font-size: 90%;
+    line-height: 1.5;
+    font-family: 'Roboto-Light', sans-serif;
+    font-weight: 50;
     margin-top: 8px;
 }
 
-@media screen and (max-width: 1250px) {
+@media screen and (max-width: 1000px) {
     p.navlink {
         font-size: 100%;
         line-height: 1.5;
@@ -1166,7 +1154,7 @@ p.navlink a span {
     max-width: 800px;
 }
 
-@media screen and (max-width: 1250px) {
+@media screen and (max-width: 1000px) {
     .copy {
         margin: 12px 4px 12px 8px;
     }
@@ -1210,7 +1198,7 @@ sup.src {
     margin-right: 0.1em;
 }
 
-@media screen and (max-width: 1250px) {
+@media screen and (max-width: 1000px) {
     .sources {
         margin: 0 4px;
     }
@@ -1258,7 +1246,7 @@ img.crest {
     margin: 0 1em 0 0;
 }
 
-@media screen and (max-width: 1250px) {
+@media screen and (max-width: 1000px) {
     .extra, .extra_left {
         display: block;
         float: none !important;
@@ -1298,7 +1286,7 @@ img.crest {
     width: 99%;
 }
 
-@media screen and (max-width: 1250px) {
+@media screen and (max-width: 1000px) {
     .content p {
         text-align: left;
     }
@@ -1348,10 +1336,10 @@ img.crest {
     grid-template-rows: auto;
     margin: 0 0 20px 0;
 }
-@media screen and (max-width: 1250px) {
+@media screen and (max-width: 1000px) {
     .grid {
+        width: 94%;
         margin-left: 0px;
-        width: 97%;
     }
 }
 
@@ -1384,7 +1372,7 @@ audio {
     text-align: center;
 }
 
-@media screen and (max-width: 1250px) {
+@media screen and (max-width: 1000px) {
     .grid {
         grid-template-columns: auto;
     }
@@ -1400,7 +1388,7 @@ audio {
     }
 }
 
-@media screen and (max-width: 1250px) {
+@media screen and (max-width: 1000px) {
     .homegriditem {
         margin-left: 8px;
     }
@@ -1452,7 +1440,7 @@ audio {
     grid-template-areas: ". ." "desc desc";
 }
 
-@media screen and (max-width: 1250px) {
+@media screen and (max-width: 1000px) {
     .grid2 {
         width: 95%;
         margin-bottom: 12px;
@@ -1485,7 +1473,7 @@ audio {
     margin-top: 0.5em;
 }
 
-@media screen and (max-width: 1250px) {
+@media screen and (max-width: 1000px) {
     .grid1 {
         margin: 8px 0 2px 0;
     }
@@ -1510,7 +1498,7 @@ audio {
     height: 443px;
 }
 
-@media screen and (max-width: 1250px) {
+@media screen and (max-width: 1000px) {
     .video {
         width: 300px;
         height: 230px;
@@ -1582,7 +1570,7 @@ div.poem p {
     color: #668;
 }
 
-@media screen and (max-width: 1250px) {
+@media screen and (max-width: 1000px) {
     p.quote {
         margin: 0.5em 1.5em 0.5em 1.5em;
         font-size: 100%;
@@ -1628,7 +1616,7 @@ p.quote:before, p.small_quote:before {
     grid-template-columns: 5fr 5fr;
     grid-template-areas: "sideimg sidedesc";
 }
-@media screen and (max-width: 1250px) {
+@media screen and (max-width: 1000px) {
     .side {
         grid-template-columns: unset;
         grid-template-areas: "sideimg" "sidedesc";
@@ -1700,7 +1688,7 @@ div.bottom {
     text-decoration: underline;
 }
 
-@media screen and (max-width: 1250px) {
+@media screen and (max-width: 1000px) {
     .peoplelist {
         box-sizing: border-box;
         width: 96%;
@@ -1719,7 +1707,7 @@ ol li {
     list-style-position: inside;
     margin: 0 0 1em 0;
 }
-@media screen and (max-width: 1250px) {
+@media screen and (max-width: 1000px) {
     ol li {
         width: 95%;
     }
@@ -1727,7 +1715,8 @@ ol li {
 .contentlist li {
     font-size: 80%;
     list-style-type: none;
-    font-family: 'SegoeUILight';
+    font-weight: 300;
+    font-family: 'Verdana';
     line-height: 1.1em;
     padding: 0px;
     margin: 0 0 4px 0;
@@ -1746,7 +1735,7 @@ ol li {
     padding: 0;
     margin-top: 3em;
 }
-@media screen and (max-width: 1250px) { 
+@media screen and (max-width: 1000px) { 
     .contentlist-in {
         margin-top: 1em;
     }
@@ -1759,7 +1748,7 @@ ol li {
     margin-left: 0;
 }
 
-@media screen and (max-width: 1250px) {
+@media screen and (max-width: 1000px) {
     .contentlist-in li {
         list-style-type: disc;
         list-style-position: inside;
@@ -1787,7 +1776,7 @@ ol li {
     border-radius: 12px;
 }
 
-@media screen and (max-width: 1250px) {
+@media screen and (max-width: 1000px) {
     .letter {
         margin-left: 8px;
         margin-right: 8px;
@@ -1803,7 +1792,7 @@ ol li {
     font-weight: bold;
 }
 
-@media screen and (max-width: 1250px) {
+@media screen and (max-width: 1000px) {
     p.ints {
         margin-top: 8px;
         margin-bottom: 0px;
@@ -1826,10 +1815,6 @@ span.inew {
     color: #d22;
 }
 
-span.count {
-    color: #909090;
-}
-
 article.ref, p.ref  {
     box-sizing: border-box;
     padding: 0 0 0 12px;
@@ -1844,14 +1829,15 @@ article.ref, p.ref  {
 article.ref > p, article.ref li {
     color: #787878;
 }
-@media screen and (max-width: 1250px) { 
+@media screen and (max-width: 1000px) { 
     article.ref  {
         width: 87%;
         margin: 42px 0 12px 8px;
         border-width: 0 12px 0 12px;
     }
     p.ref {
-        margin-left: 4px;
+        padding: 0 0 0 4px;
+        margin: 4px 0 14px 6px;
     }
 }
 
@@ -1917,7 +1903,7 @@ diet- {
     width: 30%;
     margin: 18px 0 4px 0;
 }
-@media screen and (max-width: 1250px) { 
+@media screen and (max-width: 1000px) { 
     intro- {
         margin: 8px 8px 20px 8px;
     }
@@ -1942,7 +1928,7 @@ diet- {
     width: 480px;
     height: 80px;
 }
-@media screen and (max-width: 1250px) { 
+@media screen and (max-width: 1000px) { 
     .music {
         width: 90%;
         height: 100px;

--- a/images/templates/images/album.html
+++ b/images/templates/images/album.html
@@ -1,59 +1,38 @@
 {% extends "base.html" %}
 
 {% block content %}
-
-<div class="advert">
-
+<div class="album">
 <h1>{{album.title}}</h1>
 <p class="intro">{{intro|safe}}</p>
-
-{% if spotify %}
-<p><b>Soundtrack for this album:</b></p>
-<iframe src="https://open.spotify.com/embed/{{ spotify }}" class="music" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>
+{% if spotify %}<p><b>Soundtrack for this album:</b></p>
+<iframe src="https://open.spotify.com/embed/{{ spotify }}" class="music" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>{% endif %}
+{% if next or prev %}<p class="nextprev">{% if next %}<a href="/images/{{ next.path }}">next album: {{ next.title }}</a><br />{% endif %}{% if prev %}<a href="/images/{{ prev.path }}">previous album: {{ prev.title }}</a>{% endif %}</p>
 {% endif %}
-
-{% if next or prev %}
-<p class="nextprev">{% if next %}<a href="/images/{{ next.path }}">next album: {{ next.title }}</a><br />{% endif %}{% if prev %}<a href="/images/{{ prev.path }}">previous album: {{ prev.title }}</a>{% endif %}
-</p>
-{% endif %}
-
 <script>
-  {% if next %}
-  var nextAlbum = "{{ next.path }}";
-  {% endif %}
-  {% if prev %}
-  var prevAlbum = "{{ prev.path }}";
-  {% endif %}
-</script>
-
-<section class="thumbnails">
-{% for im in images %}
-    <article class="thumb">
-	    <a href="/images/nojs?year={{ year }}&path={{ path }}&thumb={{ forloop.counter|add:'-1' }}">
-            <img src="{{ url }}/{{ im.thumb }}-s.jpg" alt="{{ im.caption|safe }}, {{ title }}" onclick="showViewer({{ forloop.counter|add:'-1' }}); return false;" />
-        </a>
-        <p>{{ im.caption|safe }}</p>
-    </article>{% endfor %}
-</section>
-
-<p class="hint">Hint: you can use the left and right cursor keys to navigate between albums, and between photos when in the photo viewer</p>
-
-</div>
-<script>
-
+  {% if next %}var nextAlbum = "{{ next.path }}";{% endif %}
+  {% if prev %}var prevAlbum = "{{ prev.path }}";{% endif %}
     var base = "{{ url }}";
     var imgCount = {{ images|length }};
     var pos = 0;
     var images = [];
+    var ids = [];
     var captions = [];
     var dimensions = {};
 {% for im in images %}
     images[{{ forloop.counter|add:"-1" }}] = "{{ im.thumb }}";
+    ids[{{ forloop.counter|add:"-1" }}] = "{{ im.id }}";
     captions[{{ forloop.counter|add:"-1" }}] = "{{ im.caption|safe }}"; {% endfor %}
 {% for im in dimensions %}
     dimensions["{{ im.name }}"] = "{{ im.ratio }}"; {% endfor %}
 </script>
-
+<section class="thumbnails">
+{% for im in images %}
+    <article class="thumb">
+	    <a href="/images/nojs?year={{ year }}&path={{ path }}&thumb={{ forloop.counter|add:'-1' }}">{% if is_webp == "true" and accept_webp == "true" %}<img src="{{ url }}/{{ im.thumb }}-s.webp"{% elif is_webp == "true" and accept_webp == "false" %}<img src="https://static.nosher.net/cdn/img2?i={{ url }}/{{ im.thumb }}-s.webp&t=jpg"{% else %}<img src="{{ url }}/{{ im.thumb }}-s.jpg"{% endif %} alt="{{ im.caption|safe }}, {{ title }}" onclick="showViewer({{ forloop.counter|add:'-1' }}); return false;" /></a>
+        <p>{{ im.caption|safe }}</p>
+    </article>{% endfor %}
+</section>
+<p class="hint">Hint: you can use the left and right cursor keys to navigate between albums, and between photos when in the photo viewer</p>
 <!-- Desktop photo viewer -->
 <div id="viewer">
     <div id="viewwindow">
@@ -61,55 +40,53 @@
             <img id="fullsize" src="" draggable="true" />
         </photoview>
         <capregion><div id="caption">{{images.0.caption|safe}}</div></capregion>
-        <photoclose><img src="{{ staticServer }}/graphics/close.png" onclick='hideViewer();' /></photoclose>
+        <photoclose><img src="{{ staticServer }}/graphics/close.webp" onclick='hideViewer();' /></photoclose>
     </div>
     <div id="wrapper">
         <section id="strip">
-            {% for im in images %}<div>
-                <img id="{{ forloop.counter }}-img" src="{{ url }}/{{ im.thumb }}-s.jpg" onclick="showImage({{forloop.counter|add:"-1"}});" />{% if im == images.0 %}
-                <div id="{{ forloop.counter }}-marker" class="hilite"></div> {% else %}
-                <div id="{{ forloop.counter }}-marker" class="lolite"></div> {% endif %}
-            </div>
-            {% endfor %}
+            {% for im in images %}<div><img id="{{ forloop.counter }}-img" src={% if is_webp == "true" and accept_webp == "true" %}"{{ url }}/{{ im.thumb }}-s.webp"{% elif is_webp == "true" and accept_webp == "false" %}"https://static.nosher.net/cdn/img2?i={{ url }}/{{ im.thumb }}-s.webp&t=jpg"{% else %}"{{ url }}/{{ im.thumb }}-s.jpg" {% endif %} onclick="showImage({{forloop.counter|add:"-1"}});" />{% if im == images.0 %}<div id="{{ forloop.counter }}-marker" class="hilite"></div> {% else %}<div id="{{ forloop.counter }}-marker" class="lolite"></div> {% endif %}</div>{% endfor %}
         </section>
     </div>
 </div>
-
 <!-- Mobile photo viewer -->
 <div id="mobile_viewer">{% for im in images %}    
     <div class="mphoto" id="mphoto_{{ forloop.counter|add:"-1" }}">
-        <img src="" id="{{ im.thumb }}" />
+        <img src="" id="{{ im.id }}" height="{{ im.height }}"/>
         <p>{{ im.caption|safe }}</p>
     </div>{% endfor %}
 </div>
-
+</div><!-- end of class=advert block -->
 <script src="https://static.nosher.net/js/jquery-3.3.1.min.js"
         integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
         crossorigin="anonymous"></script>
-
-        <script src="https://static.nosher.net/js/touchswipe.js"
+<script src="https://static.nosher.net/js/touchswipe.js"
         integrity="sha256-ztqZnG9YzCVSrlndn420J5Tq0jopsi6M+F8raET12LM="
         crossorigin="anonymous"></script>
-
 <script>
-
     var main = $('#fullsize');
     var isLandscape = false;
     var isMobile = false;
     var width = height = 0;
     var index = {{index}};
+    var webp = {{is_webp}};
+    var tail;
+    if (webp) {
+        tail = "webp";
+    } else {
+        tail = "jpg";
+    }
 
     window.addEventListener("load", function() {
         width = $(window).width();
         height = $(window).height()
         isLandscape = width > height;
-        isMobile = width < 840 // see nosher2.css for media rules defining a mobile view
+        isMobile = width < 1000 // see nosher2.css for media rules defining a mobile view
         console.log("MOBILE", isMobile)
         for (i = 0; i < imgCount; i++) {
-            var ratio = dimensions[images[i]];
+            var ratio = dimensions[ids[i]];
             var iheight = Math.floor(width * ratio);
-            $("#img" + i).height(iheight);
-            console.log("set height of #img", i, " ",images[i], ", to ", iheight);
+            $("#" + ids[i]).height(iheight);
+            console.log("set height of #" + ids[i], "to", iheight);
         };
         if (index > -1) {
             setTimeout(showViewer(index), 1500);
@@ -204,7 +181,7 @@
 
     function orientationAwareImage(position) {
         var frame = $("#mphoto_" + position);
-        var url = base + "/" + images[position] + "-m.jpg";
+        var url = base + "/" + images[position] + "-m." + tail;
         var img = frame.find("img");
         img.attr("src", url).on("load", function() {
             var lwid = img.width();
@@ -241,7 +218,7 @@
             $("#wrapper").scrollLeft(0);
         }
         main.hide();
-        var imgUrl = base + "/" + images[pos] + "-m.jpg"
+        var imgUrl = base + "/" + images[pos] + "-m." + tail
         main.attr("alt", "{{title}}, " + captions[pos]);
         main.attr("src", imgUrl).on("load", function() {
             

--- a/images/views.py
+++ b/images/views.py
@@ -59,13 +59,14 @@ def nojs(request):
         path = params.get("path")
     if "thumb" in params:
         thumb = int(params.get("thumb"))
-    (title, intro, images, mtime, dimensions) = _getAlbumDetails("{}/{}".format(year, path))
+    (title, intro, images, mtime, dimensions, webp) = _getAlbumDetails("{}/{}".format(year, path))
     img = images[thumb]
     context = {
         'year': year,
         'path': path,
         'title': title,
         'page_title': title,
+        'webp_source': webp,
         'page_description': img["caption"],
         'page_image': "{}/{}/{}/{}/{}{}".format(WEBROOT, DOCROOT, year, path, img["thumb"], "-m.jpg"),
         'staticServer': WEBROOT,
@@ -104,9 +105,14 @@ def album(request, album_year, album_path, index=-1):
                 prv = all_albums[i - 1]
             if i < len(all_albums) - 1:
                 nxt = all_albums[i + 1]
-    (title, intro, images, mtime, dimensions) = _getAlbumDetails("{}/{}".format(album_year, album_path))
+    (title, intro, images, mtime, dimensions, webp) = _getAlbumDetails("{}/{}".format(album_year, album_path))
     spotify = _getSpotifyDetails("{}/{}".format(album_year, album_path))
     fmt_date = datetime.datetime.fromtimestamp(mtime).strftime("%d %B %Y")
+    if request.META["HTTP_ACCEPT"].find("image/webp") > -1:
+        accept_webp = "true" 
+    else:
+        accept_webp = "false"
+
     context = {
         'path': album_path,
         'year': album_year,
@@ -120,6 +126,8 @@ def album(request, album_year, album_path, index=-1):
         'mtime': fmt_date,
         'dimensions': dimensions,
         'staticServer': WEBROOT,
+        'accept_webp': accept_webp,
+        'is_webp': webp,
         'years': _getYears(),
         'groups': _getGroups(),
         'index': index,
@@ -155,7 +163,7 @@ def _getAlbumDetails(album_path):
             for d in d.readlines():
                 d = d.replace("\n", "")
                 (name, ratio) = d.split("\t")
-                dims.append({"name": "{}/{}".format(album_path, name), "ratio": ratio})
+                dims.append({"name": name, "ratio": ratio})
     except Exception:
         pass # no dimensions
 
@@ -179,9 +187,13 @@ def _getAlbumDetails(album_path):
                     path = parts[0]
                     if path.find("/") < 0:
                         path = "{}/{}".format(album_path, parts[0])
-                    items.append({"thumb": path, "caption": parts[1].replace("\"","\'")})
-                
-        return (title, intro, items, stats[ST_MTIME], dims) 
+                    items.append({"thumb": path, "id": parts[0], "caption": parts[1].replace("\"","\'"), "height": 0})
+        f1 = items[0]["thumb"]
+        if os.path.exists(os.path.join(ROOT, "{}-m.webp".format(f1))):
+            webp_source = "true"
+        else :
+            webp_source = "false"
+        return (title, intro, items, stats[ST_MTIME], dims, webp_source) 
 
 
 def _getYears():
@@ -189,9 +201,7 @@ def _getYears():
     cut_off = datetime.datetime.now() - datetime.timedelta(days=60)
     clip = cut_off.strftime("%Y-%m-%d")
     for year in years:
-        count = PhotoAlbum.objects.filter(year=year.year).count()
         new_albums = PhotoAlbum.objects.filter(year=year.year).filter(date_created__gte=clip).count()
-        year.setCount(count)
         year.setHasNew(new_albums > 0)
     return years
 
@@ -220,7 +230,7 @@ def api_latest(request):
     latest = PhotoAlbum.objects.order_by('-date_created')[:30]
     output = []
     for album in latest:
-        (title, intro, items, stats, dimensions) = _getAlbumDetails(album.path)    
+        (title, intro, items, stats, dimensions, webp) = _getAlbumDetails(album.path)    
         output.append("""{{"path":"{}", "title": "{}", "thumb": "{}"}}""".format(album.path, album.title.replace("\"", "'"), items[1]["thumb"]))
     context = {
         'body': """{{"latest": [{}]}}""".format(", ".join(output)),
@@ -246,7 +256,7 @@ def api_year(request, album_year):
     albums = PhotoAlbum.objects.filter(year=album_year).order_by('-path')
     output = []
     for album in albums:
-        (title, intro, items, stats, dimensions) = _getAlbumDetails(album.path)    
+        (title, intro, items, stats, dimensions, webp) = _getAlbumDetails(album.path)    
         output.append("""{{"path":"{}", "title":"{}", "thumb": "{}"}}""".format(album.path, album.title.replace("\n", "").replace("\"", "'"), items[1]["thumb"]))
     context = {
         'body': """{{"year": [{}]}}""".format(", ".join(output)),
@@ -257,7 +267,7 @@ def api_year(request, album_year):
 
 def api_album(request, album_year, album_path):
     
-    (title, intro, items, modified, dimensions) = _getAlbumDetails(album_year + "/" + album_path)
+    (title, intro, items, modified, dimensions, webp) = _getAlbumDetails(album_year + "/" + album_path)
     output = []
     for item in items:
         output.append("""{{"thumb": "{}", "caption": "{}"}}""".format(item["thumb"], item["caption"].replace("\"", "'")))

--- a/search/templates/search/search.html
+++ b/search/templates/search/search.html
@@ -14,13 +14,13 @@
         <a href="/{{ result.path }}">
             <div id="fourbox">
             {% for img in result.imgs|split:"," %}
-                <img title="{{ result|details }}" class="tiny" src="{{ server }}/{{ result.path }}/{{ img }}-s.jpg" />
+                <img title="{{ result|details }}" class="tiny" src="{{ server }}/cdn/img2?i=/{{ result.path }}/{{ img }}-s&t=webp" />
             {% endfor %}
             </div>
         </a>
         <p>{{ result.content|ellipsize }}</p>
         {% else %}
-        <a href="/{{ result.path }}"><img src="{{ result.image }}" title="{{ result|details }}"/></a>
+        <a href="/{{ result.path }}"><img src="{{ server }}/cdn/img2?i={{ result.image }}&t=webp" title="{{ result|details }}"/></a>
         <p>{{ result.content|ellipsize }}</p>
         {% endif %}
     </article>{% endfor %}


### PR DESCRIPTION
Add support for WEBP, as recommended by Google PageSpeed insights. Currently:

1) Photo albums can be either WEBP or JPG, but not both (TODO: https://github.com/nosher/dotnet/issues/53)
2) Computer Archives (adverts) remain as JPEG (TODO: https://github.com/nosher/dotnet/issues/52)
3) Search results are all converted to WEBP for display (at the current cost of redundantly converting some webp images to webp, see https://github.com/nosher/dotnet/issues/55)

See also https://github.com/nosher/dotnet/issues/54